### PR TITLE
[fix] JoinApplicationの要件(内容)変更が__str__に適用されていなかった不具合を修正

### DIFF
--- a/techuni_object/join_application.py
+++ b/techuni_object/join_application.py
@@ -93,4 +93,4 @@ class JoinApplication:
 
     def __str__(self):
         # 全項目列挙
-        return f"JoinApplication({self.id}, {self.applied_at}, {self.mail_address}, {self.name}, {self.school}, {self.department}, {self.grade}, {self.reason}, {self.opportunity}, {self.possible_dates})"
+        return f"JoinApplication({self.id}, {self.applied_at}, {self.mail_address}, {self.name}, {self.school}, {self.department}, {self.grade}, {self.opportunity}, {self.reason}, {self.goal}, {self.product})"


### PR DESCRIPTION
close なし

## やったこと

#2 で適用されたJoinApplicationの要件変更(面接->ES)によって、メンバ変数が変更されたが__str__について変更が漏れており、strキャスト等したときにエラーがでていたのでこれを修正

## やってないこと

なし

## テスト

テストデータを使用し、正しくstr化できているかをprintチェック

## その他

なし
