### PR TITLE
[fix] templateファイルがない場合にopenでタイムアウトする不具合を修正

### DIFF
--- a/techuni/techuni_object/join_application.py
+++ b/techuni/techuni_object/join_application.py
@@ -83,6 +83,8 @@ class JoinApplication:
     @classmethod
     def from_template(cls) -> str:
         if cls._appl_template is None:
+            if not os.path.exists(cls._appl_template_file):
+                raise FileNotFoundError(f"Template file({cls._appl_template_file}) is not found")
             with codecs.open(cls._appl_template_file, "r", "utf-8") as f:
                 cls._appl_template = f.read()
         return cls._appl_template


### PR DESCRIPTION
close なし

## やったこと

JoinApplicationからDiscordに送るメッセージを作るテンプレートファイルが存在しない場合に、タイムアウトする場合がある不具合を修正

## やってないこと

なし

## テスト

テスト起動

## その他

なし
