### PR TITLE
[fix] 特定のメールヘッダが指定された際にDKIMが失敗する不具合を修正

### DIFF
--- a/techuni/techuni_email/email_controller.py
+++ b/techuni/techuni_email/email_controller.py
@@ -2,6 +2,7 @@ import time
 import imaplib
 import email.utils
 from email.message import EmailMessage
+from email.header import Header
 from techuni.techuni_email import EmailTemplate, EmailClientManager
 
 class EmailController:
@@ -15,11 +16,11 @@ class EmailController:
         with self._client_manager.get(template.from_address) as from_client:
             msg = EmailMessage()
             msg["Message-ID"] = email.utils.make_msgid(domain=from_client.get_domain())
-            msg["From"] = from_client.get_header()
+            msg["From"] = EmailController._encode_header(from_client.get_header())
             msg["To"] = ", ".join(to)
-            msg["Subject"] = template.subject
+            msg["Subject"] = EmailController._encode_header(template.subject)
             msg["Date"] = email.utils.formatdate()
-            msg["Organization"] = from_client.organization
+            msg["Organization"] = EmailController._encode_header(from_client.organization)
 
             for subtype in template.subtypes:
                 content = template.get_template(subtype)
@@ -43,3 +44,7 @@ class EmailController:
             val = getattr(obj, attr)
             template = template.replace(f"%%{attr}%%", str(val))
         return template
+
+    @staticmethod
+    def _encode_header(content):
+        return Header(content, "utf-8").encode(maxlinelen=0)


### PR DESCRIPTION
close #57

## やったこと
- str系メールヘッダ(From, Subject, Organization)でnon-ASCIIの値をRFC準拠でラップする処理を追加
<!-- このプルリクで何をしたのか？ -->

## やってないこと
- なし
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## テスト
- 漢字やひらがな(=non-ASCII)がまじったFrom, Subject, Organizationをemail-clientsやtemplateに設定して、dev環境でテストデータを投げてテスト
<!-- テスト方法を書く -->

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
