### PR TITLE
[fix] プールされているconnectionが無効な場合がある不具合の修正

### DIFF
--- a/techunibot.py
+++ b/techunibot.py
@@ -16,7 +16,7 @@ def socket_main(queue):
 
 def main():
     # Database
-    database_engine = create_engine(str(os.environ.get("DATABASE_URL")), echo=False)
+    database_engine = create_engine(str(os.environ.get("DATABASE_URL")), echo=False, pool_pre_ping=True)
     session_factory = sessionmaker(bind=database_engine, autoflush=True, autocommit=False)
 
     ## init database


### PR DESCRIPTION
close なし

## やったこと
- MySQLなどコネクションを一定時間で閉じる系のDBを使う場合に、切断されているコネクションをプールからチェックアウト・使用してエラーが出る不具合を修正
<!-- このプルリクで何をしたのか？ -->

## やってないこと
- なし
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## テスト

<!-- テスト方法を書く -->

## その他
- [pool_pre_ping のDocument](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic)
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
